### PR TITLE
linux-tegra_%.bbapend: Add all configs needed for the CAN bus

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0002-mttcan-ivc-enable.patch
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0002-mttcan-ivc-enable.patch
@@ -1,0 +1,34 @@
+From e60a72a72f68f516413d7c2e9c690328777d90fe Mon Sep 17 00:00:00 2001
+From: Vicentiu Galanopulo <vicentiu@balena.io>
+Date: Tue, 23 Apr 2019 17:06:08 +0200
+Subject: [PATCH] Enable mttcan-ivc for the CAN bus
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ nvidia/soc/t18x/kernel-dts/tegra186-soc/tegra186-aon.dtsi | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/nvidia/soc/t18x/kernel-dts/tegra186-soc/tegra186-aon.dtsi b/nvidia/soc/t18x/kernel-dts/tegra186-soc/tegra186-aon.dtsi
+index 7ee4278..7614ee5 100644
+--- a/nvidia/soc/t18x/kernel-dts/tegra186-soc/tegra186-aon.dtsi
++++ b/nvidia/soc/t18x/kernel-dts/tegra186-soc/tegra186-aon.dtsi
+@@ -87,13 +87,13 @@
+ 	mttcan0-ivc {
+ 		compatible = "bosch,mttcan-ivc";
+ 		mboxes = <&aon 3>;
+-		status = "disabled";
++		status = "okay";
+ 	};
+ 
+ 	mttcan1-ivc {
+ 		compatible = "bosch,mttcan-ivc";
+ 		mboxes = <&aon 4>;
+-		status = "disabled";
++		status = "okay";
+ 	};
+ };
+ 
+-- 
+2.7.4
+

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -3,13 +3,14 @@ inherit kernel-resin deploy
 FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 SRC_URI_append = " \
     file://0001-Expose-spidev-to-the-userspace.patch \
+    file://0002-mttcan-ivc-enable.patch \
     file://tegra186-tx2-cti-ASG001-USB3.dtb \
     file://tegra186-quill-p3310-1000-c03-00-base.dtb \
     file://tegra186-tx2-cti-ASG006-IMX274-6CAM.dtb \
     file://tegra186-tx2-cti-ASG916.dtb \
     "
 
-RESIN_CONFIGS_append = " compat spi gamepad"
+RESIN_CONFIGS_append = " compat spi gamepad can"
 RESIN_CONFIGS_remove = "brcmfmac"
 
 RESIN_CONFIGS[compat] = " \
@@ -40,6 +41,14 @@ RESIN_CONFIGS_DEPS[cdc_acm] = "CONFIG_TTY=y"
 RESIN_CONFIGS[cdc_acm] = "CONFIG_USB_ACM=m"
 
 RESIN_CONFIGS[wdm] = "CONFIG_USB_WDM=m"
+
+RESIN_CONFIGS[can] = " \
+		CONFIG_CAN=m \
+		CONFIG_CAN_RAW=m \
+		CONFIG_CAN_DEV=m \
+		CONFIG_MTTCAN=m \
+		CONFIG_MTTCAN_IVC=m \
+"
 
 TEGRA_INITRAMFS_INITRD = "0"
 


### PR DESCRIPTION
According to the nVIDIA-https://docs.nvidia.com/drive/nvvib_docs
development guide for the CAN bus, the CAN driver must be enabled
and the specific CAN kernel config options need to be specified.

Changelog-entry: CAN bus enablement
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>