### PR TITLE
bluez5_%.bbappend: Add hciattach service file

### DIFF
--- a/layers/meta-balena-jetson/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/files"
+
+inherit systemd
+
+SRC_URI += " \
+        file://hciattach.service \
+        "
+
+SYSTEMD_SERVICE_${PN} = "hciattach.service"
+
+do_install_append() {
+        install -d ${D}/${systemd_unitdir}/system
+        install -m 644 ${WORKDIR}/hciattach.service ${D}/${systemd_unitdir}/system
+}

--- a/layers/meta-balena-jetson/recipes-connectivity/bluez5/files/hciattach.service
+++ b/layers/meta-balena-jetson/recipes-connectivity/bluez5/files/hciattach.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run hciattach when HCI UART device becomes available
+Before=bluetooth.service
+Wants=dev-ttyTHS3.device
+After=dev-ttyTHS3.device
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/hciattach ttyTHS3 any
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The HCI UART device /dev/ttyTHS3 is used for
bluetooth and the hciattach command needs to
be done before starting the bluetooth.service.

Changelog-entry: Added hciattach service file
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>