### PR TITLE
linux-tegra: Only enable TPG for machines that have the hardware

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -11,7 +11,7 @@ SRC_URI_append = " \
     file://d3-rsp-fpdlink-ov10640-single-j2.dtb \
     "
 
-RESIN_CONFIGS_append = " compat spi gamepad can tpg"
+RESIN_CONFIGS_append = " compat spi gamepad can"
 RESIN_CONFIGS_remove = "brcmfmac"
 
 RESIN_CONFIGS[compat] = " \
@@ -51,6 +51,7 @@ RESIN_CONFIGS[can] = " \
 		CONFIG_MTTCAN_IVC=m \
 "
 
+RESIN_CONFIGS_append_srd3-tx2 = " tpg"
 RESIN_CONFIGS[tpg] = " \
 		CONFIG_VIDEO_TEGRA_VI_TPG=y \
 "


### PR DESCRIPTION
Having this enabled on all machines, for example the TX2 devkit,
the kernel crashes in the following way:

Call trace:
[<ffffffc001106664>] tpg_probe_t18x+0x44/0x1a4
[<ffffffc000081d40>] do_one_initcall+0xd0/0x1f0
[<ffffffc0010cdbe4>] kernel_init_freeable+0x1d4/0x278
[<ffffffc000b5e158>] kernel_init+0x18/0xe0
[<ffffffc000084f90>] ret_from_fork+0x10/0x40
 ---[ end trace 3074e38319bcd9c9 ]---
Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b

Changelog-entry: Set VIDEO_TEGRA_VI_TPG as built-in only for machines that have the hardware
Signed-off-by: Florin Sarbu <florin@balena.io>