### PR TITLE
linux-tegra_%.bbappend: Compile video tpg as module

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -51,9 +51,14 @@ RESIN_CONFIGS[can] = " \
 		CONFIG_MTTCAN_IVC=m \
 "
 
+RESIN_CONFIGS_append_srd3-tx2 = " tpg"
+
 RESIN_CONFIGS[tpg] = " \
-		CONFIG_VIDEO_TEGRA_VI_TPG=y \
+		CONFIG_VIDEO_TEGRA_VI_TPG=m \
 "
+
+KERNEL_MODULE_AUTOLOAD_srd3-tx2 += "nvhost-vi-tpg"
+KERNEL_MODULE_PROBECONF_srd3-tx2 += "nvhost-vi-tpg"
 
 TEGRA_INITRAMFS_INITRD = "0"
 


### PR DESCRIPTION
The nvhost-vi-tpg module was added as part of the kernel
but the following oops was showing up on all tx2-boards:

Unable to handle kernel NULL pointer dereference at virtual address 00000000
pgd = ffffffc0017cb000
[00000000] *pgd=000000026cda5003, *pud=000000026cda5003, *pmd=000000026cda6003, *pte=00e8000003881707
Internal error: Oops: 96000005 [#1] PREEMPT SMP
Modules linked in:
CPU: 0 PID: 1 Comm: swapper/0 Not tainted 4.4.38-l4t-r28.2+g174510d #2
Hardware name: quill (DT)
task: ffffffc1ece48000 ti: ffffffc1ece50000 task.ti: ffffffc1ece50000
PC is at tpg_probe_t18x+0x44/0x1a4
LR is at tpg_probe_t18x+0x34/0x1a4
pc : [<ffffffc001106664>] lr : [<ffffffc001106654>] pstate: 80000045

This commit fixes this.

Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>